### PR TITLE
RFC: Perform FS actions only for given types

### DIFF
--- a/autostart.d/image.sh
+++ b/autostart.d/image.sh
@@ -86,12 +86,17 @@ esac
 # write OS image
 eval "${FETCH} | ${WRITE}"
 
-# make sure filesystem matches partition size.
-# temporary install rpm's until next version of discovery image.
-rpm -ivh --nodeps http://mirror.nsc.liu.se/CentOS/7.3.1611/os/x86_64/Packages/e2fsprogs-libs-1.42.9-9.el7.x86_64.rpm
-rpm -ivh --nodeps http://mirror.nsc.liu.se/CentOS/7.3.1611/os/x86_64/Packages/e2fsprogs-1.42.9-9.el7.x86_64.rpm
-e2fsck -p -f /dev/${PARTITION}
-resize2fs /dev/${PARTITION}
+# run extra actions per filesystem type
+case $(blkid | grep /dev/${PARTITION} | sed -e 's/.*TYPE="\(\S*\)".*/\1/') in
+  ext*)
+    # make sure filesystem matches partition size.
+    # temporary install rpm's until next version of discovery image.
+    rpm -ivh --nodeps http://mirror.nsc.liu.se/CentOS/7.3.1611/os/x86_64/Packages/e2fsprogs-libs-1.42.9-9.el7.x86_64.rpm
+    rpm -ivh --nodeps http://mirror.nsc.liu.se/CentOS/7.3.1611/os/x86_64/Packages/e2fsprogs-1.42.9-9.el7.x86_64.rpm
+    e2fsck -p -f /dev/${PARTITION}
+    resize2fs /dev/${PARTITION}
+    ;;
+esac
 
 # mount OS partition
 mkdir /target


### PR DESCRIPTION
Because the ext suite of tools really don't like XFS partitions - the CentOS default.

This should probably be extended to allow extending partitions for more than just ext-based systems, not all file systems can be expanded online by cloud-init after all.

Perhaps a more suitable way to solve the issue would be a pre-mount script for this.